### PR TITLE
Update Setup for Azahar Emulator

### DIFF
--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -15,6 +15,7 @@
  - If you already have an `albwrandomizer` *file* in your `lib` folder from a previous version, remove it.
  - If running from source, place the `albwrandomizer` folder in your `Archipelago` folder instead.
 4. In the emulator, select `File > Open Azahar Folder`. Create a `load` folder inside this folder, and inside the `load` folder create a `mods` folder.
+5. Also in the emulator, select `Emulation > Configure`. Then, in the general section, on the top, select `Debug`. Finally, at the bottom, ensure that the `Enable RPC Server` option is enabled.
 
 ## Generating a Game
 


### PR DESCRIPTION
Both of the previously-recommended emulators, `Lime3DS` and `Citra`, are no longer maintained. (their repositories have been archived). For this reason, I believe that it is important to update the setup documentation accordingly. The Azahar emulator works with the randomizer out-of-the-box, only needing to enable RPC in the debug settings. Perhaps, it should also be mentioned that `.3ds` files would need to be renamed to `.cci`, but I did not add this change.