### PR TITLE
Prevent This APWorld From Not Working In Archipelago v0.7.0 and newer

### DIFF
--- a/archipelago.json
+++ b/archipelago.json
@@ -1,6 +1,8 @@
 {
-    "game": "A Link Between Worlds",
-    "authors": ["randomsalience"],
+    "minimum_ap_version": "0.5.0", 
     "world_version": "0.1.3",
-    "minimum_ap_version": "0.5.0"
+    "authors": ["randomsalience"],
+    "version": 7,
+    "compatible_version": 7,
+    "game": "A Link Between Worlds"
 }


### PR DESCRIPTION
You need to add the archipelago.json file to this project because on Archipelago version 0.7.0 and newer, your apworld for The Legend of Zelda: A Link Between Worlds will no longer be compatiable with the new version of Archipelago. Version 0.6.4 is the last compatiable version of Archipelago that this apworld will stop working in (If i'm not mistaken). It is best if you merge this PR so that you don't have to worry about that happening. you may also modify the archipelago.json file if you want.